### PR TITLE
Fix starterpack 19s typos

### DIFF
--- a/assignments/lab/react-notes/index.md
+++ b/assignments/lab/react-notes/index.md
@@ -37,7 +37,7 @@ In this version your notes will persist and will synchronize in real-time so mul
 
 ```bash
 #make sure you are in your project directory
-git remote add starter git@github.com:dartmouth-cs52-19s/starterpack-your-gitub-username.git
+git remote add starter git@github.com:dartmouth-cs52-20s/starterpack-your-gitub-username.git
 git pull starter master  # you may need --allow-unrelated-histories
 ```
 

--- a/assignments/lab/redux-blog/index.md
+++ b/assignments/lab/redux-blog/index.md
@@ -32,7 +32,7 @@ We will rip out `cs52-blog.herokuapp.com` and build our own Nodejs+Express+Mongo
 
 ```bash
 #make sure you are in your project directory
-git remote add starter git@github.com:dartmouth-cs52-19s/starterpack-your-gitub-username.git
+git remote add starter git@github.com:dartmouth-cs52-20s/starterpack-your-gitub-username.git
 git pull starter master  # you may need --allow-unrelated-histories
 ```
 

--- a/assignments/sa/server-side/index.md
+++ b/assignments/sa/server-side/index.md
@@ -22,13 +22,13 @@ brew install mongodb
 
 More Mongo [installation instructions here](https://docs.mongodb.com/manual/installation/#mongodb-community-edition).
 
-We're going to be building a poll site, where users can sign various polls. We will be using [express-babel-starter](https://github.com/dartmouth-cs52-19S/express-babel-starter) to start — take a look through the `package.json` file. Mostly this sets us up with an `express` node server with a tiny bit of boiler plate as well as linting and babel.  You could easily recreate this, but for now we'll save you some time by providing it for you.
+We're going to be building a poll site, where users can sign various polls. We will be using [express-babel-starter](https://github.com/dartmouth-cs52/express-babel-starter) to start — take a look through the `package.json` file. Mostly this sets us up with an `express` node server with a tiny bit of boiler plate as well as linting and babel.  You could easily recreate this, but for now we'll save you some time by providing it for you.
 
 🚀 Do what you did in [lab4](../../lab/redux-blog) when pulling from your own starterpack but in this case we'll pull from a different starter — create your repo with the usual github classroom link from canvas, add a starter remote to this premade starter pack, and pull from it.
 
 ```bash
 #make sure you are in your project directory
-git remote add starter git@github.com:dartmouth-cs52-19S/express-babel-starter.git
+git remote add starter git@github.com:dartmouth-cs52/express-babel-starter.git
 git pull starter master
 ```
 


### PR DESCRIPTION
- fixed starterpack urls for react notes and redux blog that referenced 19s gh org instead of 20s
- fixed `express-babel-starter` starterpack url for server-side short that referenced 19s gh org instead of `dartmouth-cs52` org