### PR TITLE
updated instructions on how to turn on auto lint on save

### DIFF
--- a/assignments/sa/starterpack/index.md
+++ b/assignments/sa/starterpack/index.md
@@ -485,7 +485,9 @@ yarn add --dev eslint-config-airbnb eslint-plugin-import eslint-plugin-jsx-a11y 
 
 If you find a rule you want to modify, or ignore — you can add it in above.  `0` means turn off, `1` means warning, `2` means throw an error, with additional options available per each rule's description page.
 
-🚀 Now in VSCode -> Preferences -> Settings -> search: eslint -> and check "Eslint: Auto Fix On Save" or in Atom -> Preferences -> Packages -> linter-eslint -> Settings, and check "Fix Errors on Save".
+🚀 Now in VSCode -> Preferences -> Settings -> search: `editor.codeActionsOnSave` -> and click Edit in settings.json -> add this line to the JSON file: `"editor.codeActionsOnSave": { "source.fixAll.eslint": true },` -> save the file.
+
+🚀 Now in Atom -> Preferences -> Packages -> linter-eslint -> Settings, and check "Fix Errors on Save".
 
 Super useful. This will fix indentation problems and some other things automatically whenever you save. Now restart your editor.
 


### PR DESCRIPTION
# updated instructions on how to turn on auto lint on save

VSCode changed where the settings config is to turn on auto linting on save. Changed SA3 starter pack instructions so students can turn on this feature.

![image](https://user-images.githubusercontent.com/45774151/79928204-4595a680-8410-11ea-8b08-816cc6f8c416.png)
