### PR TITLE
added requirement to turn in repo url for labs 1&2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -270,4 +270,4 @@ DEPENDENCIES
   jekyll-algolia
 
 BUNDLED WITH
-   1.17.2
+   2.1.4

--- a/assignments/lab/landing-page/index.md
+++ b/assignments/lab/landing-page/index.md
@@ -277,7 +277,7 @@ You should host this on github pages as you have in the past with the `gh-pages`
 
 ## To Turn In (canvas):
 
-* url to your hosted page (gh-pages is fine)
+* urls to your hosted page (gh-pages is fine) **and** your GitHub repository
 * your page should:
   * display as many elements from the original site as possible
   * use only pure CSS/HTML

--- a/assignments/lab/quizzical/index.md
+++ b/assignments/lab/quizzical/index.md
@@ -312,7 +312,7 @@ You should host this on github pages as you have in the past.  Remember to have 
 
 ## To Turn In:
 
-* url to your hosted page (gh-pages enabled on your classroom repo is fine)
+* urls to your hosted page (gh-pages enabled on your classroom repo is fine) **and** your classroom repo
 * your page should have all the [MVP specs](#minimal-functional-specs) in addition to:
   * have clear document structure with proper semantic naming
   * functional calculations and error checking to get quiz results


### PR DESCRIPTION
The current "To Turn In" sections of labs 1 and 2 don't ask for a GitHub repository URL. Adding this should streamline grading and increase uniformity with other lab submissions.