### PR TITLE
switching master to main

### DIFF
--- a/assignments/lab/react-notes/index.md
+++ b/assignments/lab/react-notes/index.md
@@ -38,7 +38,7 @@ In this version your notes will persist and will synchronize in real-time so mul
 ```bash
 #make sure you are in your project directory
 git remote add starter git@github.com:dartmouth-cs52-20s/starterpack-your-gitub-username.git
-git pull starter master  # you may need --allow-unrelated-histories
+git pull starter main  # you may need --allow-unrelated-histories
 ```
 
 ```bash

--- a/assignments/lab/redux-platform/index.md
+++ b/assignments/lab/redux-platform/index.md
@@ -43,7 +43,7 @@ We will rip out `platform.cs52.me/api` and build our own Nodejs+Express+Mongo ba
 ```bash
 #make sure you are in your project directory
 git remote add starter git@github.com:dartmouth-cs52-20s/starterpack-your-gitub-username.git
-git pull starter master  # you may need --allow-unrelated-histories
+git pull starter main  # you may need --allow-unrelated-histories
 ```
 
 ```bash

--- a/assignments/project/dev-site.md
+++ b/assignments/project/dev-site.md
@@ -53,7 +53,7 @@ You should set this up for *all* your repositories.  You already have working `.
 
 ![](img/Heroku_logo.png){:  .tiny}
 
-Set up your Heroku app to be connected to GitHub with [automatic deploys](https://devcenter.heroku.com/articles/github-integration#automatic-deploys).  Set this up so that whenever you merge a pull-request into your master branch for your server component, Heroku will pick up the change.  You will obviously still work locally on your own feature branches. Your master branch will be the branch that is tested and working.  You can set this up so that Heroku only updates if the Travis tests have completed successfully.
+Set up your Heroku app to be connected to GitHub with [automatic deploys](https://devcenter.heroku.com/articles/github-integration#automatic-deploys).  Set this up so that whenever you merge a pull-request into your main branch for your server component, Heroku will pick up the change.  You will obviously still work locally on your own feature branches. Your main branch will be the branch that is tested and working.  You can set this up so that Heroku only updates if the Travis tests have completed successfully.
 
 ### Continuous Integration Frontend
 
@@ -77,7 +77,7 @@ for instance if you have to customize what it runs on install and have a main de
 
 ## Such Dev Environment
 
-Now, you can work in your local environment on your feature branch and when you are ready, merge it into master which will deploy it automatically. Do not simply start using the master branch and the dev site directly as your primary method of testing.  You should always be working locally first! But this does allow you to merge in changes quickly and you can have a shared dev site where you can see the latest pushed version of everyone's code and ask others for feedback.
+Now, you can work in your local environment on your feature branch and when you are ready, merge it into main which will deploy it automatically. Do not simply start using the main branch and the dev site directly as your primary method of testing.  You should always be working locally first! But this does allow you to merge in changes quickly and you can have a shared dev site where you can see the latest pushed version of everyone's code and ask others for feedback.
 
 
 ## To Turn In:

--- a/assignments/sa/express-starterpack-unused/index.md
+++ b/assignments/sa/express-starterpack-unused/index.md
@@ -573,9 +573,9 @@ Great! We have everything working now. We will need to host this new server comp
 
 1. Head over to [Heroku](https://www.heroku.com/) and login/sign up. Then, make a new app.
 1. Follow the steps under "Deploy Using Heroku Git".  But really all you need is to add a new git remote - find your heroku git URL by going to "Settings" and then do `git remote add heroku https://git.heroku.com/cs52-blog.git`.   
-1. To host on heroku all you need to do is `git push heroku master`, this will push your code and run the npm command that is listed in your `Procfile` to launch your app.  COOL!
+1. To host on heroku all you need to do is `git push heroku main`, this will push your code and run the npm command that is listed in your `Procfile` to launch your app.  COOL!
 
-Note: Don't forget to push master to **both** heroku and origin.
+Note: Don't forget to push main to **both** heroku and origin.
 
 ## MongoDB Atlas 
 

--- a/assignments/sa/git-map/index.md
+++ b/assignments/sa/git-map/index.md
@@ -18,7 +18,7 @@ If you need help, post in the #sa2-git-map Slack channel.
 
 1. URLs to your successfully closed pull requests (you can find your pull requests [here](https://github.com/dartmouth-cs52-21S/git-map/pulls?q=is%3Apr+is%3Aclosed)). Its ok and normal to have several of these, you don't have to have gotten it right the first time. Requirements:
   * your [github username and email are correctly set](https://help.github.com/en/articles/why-are-my-commits-linked-to-the-wrong-user)
-  * you made a branch and did a pull request that was successfully merged into **dartmouth-cs52-20X/git-map:master**
+  * you made a branch and did a pull request that was successfully merged into **dartmouth-cs52-21S/git-map:main**
   * your face marker appears on the main page:  http://map.cs52.me
   * and your marker is clickable and shows your people page
 1. A short answer response to:

--- a/assignments/sa/localdev/index.md
+++ b/assignments/sa/localdev/index.md
@@ -151,7 +151,7 @@ Note: to quit the python server type: ctrl+c
 
 ```bash
 💻 git status  #check and see what the story is
-On branch master
+On branch main
 
 Initial commit
 
@@ -163,7 +163,7 @@ Untracked files:
 nothing added to commit but untracked files present (use "git add" to track)
 💻 git add index.html  #lets track index.html
 💻 git status  #check again -- I'm OCD with this
-On branch master
+On branch main
 
 Initial commit
 
@@ -173,7 +173,7 @@ Changes to be committed:
   new file:   index.html
 
 💻 git commit -am "its hideous"   #please make yours prettier 😃
-[master (root-commit) 93a5c69] its hideous
+[main (root-commit) 93a5c69] its hideous
  1 file changed, 10 insertions(+)
  create mode 100644 index.html
 ```
@@ -187,8 +187,8 @@ So lets rename our branch!
 
 ```bash
 💻 git branch
- * master
-💻 git branch -m master gh-pages
+ * main
+💻 git branch -m main gh-pages
 💻 git branch
  * gh-pages
 ```

--- a/assignments/sa/react-videos/index.md
+++ b/assignments/sa/react-videos/index.md
@@ -21,12 +21,12 @@ Today we'll be learning about [React](https://facebook.github.io/react/)!  So fa
 ```bash
 #make sure you are in your project directory
 git remote add starter git@github.com:dartmouth-cs52-20s/starterpack-your-gitub-username.git
-git pull starter master
+git pull starter main
 ```
 
 What just happened?  You merged in the git tree from another repo (the remote we named starter) into your own! Hopefully you'll build on your starter repo and use it for lots of projects.
 
-⚠️ *If you get an error about unrelated histories, that is ok, do `git pull starter master --allow-unrelated-histories`. And if it complains about un-merged files but there aren't any conflicts you may need to:  `git add` those files and then `git commit`.*
+⚠️ *If you get an error about unrelated histories, that is ok, do `git pull starter main --allow-unrelated-histories`. And if it complains about un-merged files but there aren't any conflicts you may need to:  `git add` those files and then `git commit`.*
 
 ## Setup
 
@@ -150,7 +150,7 @@ At this point you will want to push these changes to your starter pack!  This wi
 🚀 Git `add`, `commit` and:
 
 ```bash
-git push starter master
+git push starter main
 ```
 
 Since we added your starterpack repo as a remote named `starter` you can push to it even though after this point we'll diverge.

--- a/assignments/sa/redux/index.md
+++ b/assignments/sa/redux/index.md
@@ -404,9 +404,9 @@ Navigate to your repository on the command line and pull in the updates you've j
 
 ``` bash
 cd sa4-YOUR_USERNAME
-git pull origin master #just in case
+git pull origin main #just in case
 git checkout -b redux-sa #create a new branch redux-sa
-git pull starter master  #pull in your updated starter code!
+git pull starter main  #pull in your updated starter code!
 ```
 Hopefully, you should only have major conflicts in your `src/index.js` file. Let's handle them now!
 
@@ -788,7 +788,7 @@ Play with the *slider* and note how you can export and import state. Imagine how
 
 ## Release it!
 
-Commit and push your changes to your new redux branch of SA4 `git push origin redux-sa`. No need to merge into master! Deploy it somewhere on surge and include the deployed url in your submission.
+Commit and push your changes to your new redux branch of SA4 `git push origin redux-sa`. No need to merge into main! Deploy it somewhere on surge and include the deployed url in your submission.
 
 # To Turn In (Canvas)
 
@@ -807,4 +807,4 @@ Commit and push your changes to your new redux branch of SA4 `git push origin re
 * [Learning resources](https://redux.js.org/introduction/learning-resources)
 * [css-tricks.com/learning-react-redux/](https://css-tricks.com/learning-react-redux/)
 * [Redux integration with React Router](https://reacttraining.com/react-router/web/guides/redux-integration)
-* [React Router Redux Docs](https://github.com/reacttraining/react-router/tree/master/packages/react-router-redux)
+<!-- * [React Router Redux Docs](https://github.com/reacttraining/react-router/tree/master/packages/react-router-redux) -->

--- a/assignments/sa/server-side/index.md
+++ b/assignments/sa/server-side/index.md
@@ -530,8 +530,8 @@ Great! We have everything working now. We will need to host this new server comp
 
 1. Head over to [Heroku](https://www.heroku.com/) and login/sign up. Then, create a new app.
 3. Go to *Deploy* and select either "Github" or "Heroku Git" as your Deployment Method
-    * if you choose GitHub, find and connect to the right repository, then turn on *Automatic Deploys* for the master branch. This will update Heroku whenever you `git push origin master` and restart your heroku server. This way is pretty automatic and you don't have to worry about remembering to push to heroku.
-    * if you are doing "Heroku Git", select Download and install the Heroku CLI using `brew install heroku/brew/heroku`. Given that you're already working in a git repository, use `heroku git:remote -a YOUR_HEROKU_APP` to add a new git remote (use `git remote -v` to see). If you haven't done so already, add and commit your changes. Now when you want to deploy do: `git push heroku master`. *Note: Don't forget to push master to **both** heroku and origin.* This way is more manual if you want greater control.
+    * if you choose GitHub, find and connect to the right repository, then turn on *Automatic Deploys* for the main branch. This will update Heroku whenever you `git push origin main` and restart your heroku server. This way is pretty automatic and you don't have to worry about remembering to push to heroku.
+    * if you are doing "Heroku Git", select Download and install the Heroku CLI using `brew install heroku/brew/heroku`. Given that you're already working in a git repository, use `heroku git:remote -a YOUR_HEROKU_APP` to add a new git remote (use `git remote -v` to see). If you haven't done so already, add and commit your changes. Now when you want to deploy do: `git push heroku main`. *Note: Don't forget to push main to **both** heroku and origin.* This way is more manual if you want greater control.
 4. Either way, once Heroku gets your push then it will run the yarn command that is listed in your `Procfile` to launch your app.  COOL!
 
 

--- a/assignments/sa/slack-bot/index.md
+++ b/assignments/sa/slack-bot/index.md
@@ -136,7 +136,7 @@ Ok now your Bot knows how to say hi.  But let's make it do some useful stuff!
 
 The rest of this assignment is more hands-off. We'll provide some direction and resources but you'll be looking up API docs and adding more cool stuff to your bot.
 
-So far we've been using Botkit.  [Botkit](https://github.com/howdyai/botkit) has support for more complex [conversations](https://github.com/howdyai/botkit/blob/master/examples/convo_bot.js). This might come in handy.
+<!-- So far we've been using Botkit.  [Botkit](https://github.com/howdyai/botkit) has support for more complex [conversations](https://github.com/howdyai/botkit/blob/master/examples/convo_bot.js). This might come in handy. -->
 
 
 The Botkit library provides us with a convenient wrapper around Slack's API. Our bot connects to Slack's RTM API and opens a WebSocket connection with Slack. *If you set `debug=true` in the botkit initialization you can see how it polls the Slack servers.*
@@ -144,7 +144,7 @@ The Botkit library provides us with a convenient wrapper around Slack's API. Our
 ### Events
 The Slack server issues **events** that are then consumed by clients. These are things like [messages](https://api.slack.com/events/message) and [team join](https://api.slack.com/events/team_join) events. Botkit can hook up to any of Slack's events.  `.hears` is a fancier way of listening to message events.   
 
-🚀Botkit [slack event integration](https://github.com/howdyai/botkit/blob/master/docs/slack-events-api.md).
+<!-- 🚀Botkit [slack event integration](https://github.com/howdyai/botkit/blob/master/docs/slack-events-api.md). -->
 
 For instance:
 

--- a/assignments/sa/starterpack/index.md
+++ b/assignments/sa/starterpack/index.md
@@ -14,7 +14,7 @@ Today we'll be learning about a set of tools for making your code compact and pr
 💻 : run in Terminal<br>
 🚀 : a step to not forget
 
-🚀 To start grab the github classroom link in canvas to start a new repository. Work in the `master` branch for now, you'll see why later.
+🚀 To start grab the github classroom link in canvas to start a new repository. Work in the `main` branch for now, you'll see why later.
 
 ## Today's Stack
 
@@ -794,7 +794,7 @@ These are the compiled/built output files — the actual files that the browser 
 
 This will build your app into the `dist` directory and the deploy all the right stuff to surge.
 
-🚀 git `add`, `commit`, `push` all the code that is currently in your `master` branch to your `origin master` branch. You should now have:  `master` branch with `/src` and all your webpack and package files.
+🚀 git `add`, `commit`, `push` all the code that is currently in your `main` branch to your `origin main` branch. You should now have:  `main` branch with `/src` and all your webpack and package files.
 
 ## Release V1
 


### PR DESCRIPTION
@aarish407 and I switched all references of `master` to `main` except for references to the babel starter pack, since the branch is still `master` in the cs52 organization. We found a couple of broken links when checking for main/master compatibility (i.e. we only looked at links with `master` in the url), namely one for [react router redux](https://github.com/reacttraining/react-router/tree/master/packages/react-router-redux) and everything related to [botkit.ai](botkit.ai) in the slackbot assignment (of the links, I think [https://github.com/howdyai/botkit/blob/master/examples/convo_bot.js](https://github.com/howdyai/botkit/blob/master/examples/convo_bot.js) moved to [https://botkit.ai/docs/v4/conversations.html](https://botkit.ai/docs/v4/conversations.html), but since I haven’t seen the former, I’m not sure). Please let either of us know if there are any issues! Thanks!