### PR TITLE
Master to main

### DIFF
--- a/assignments/lab/redux-platform+server/index.md
+++ b/assignments/lab/redux-platform+server/index.md
@@ -33,7 +33,7 @@ First we should do some basic setup steps.
 ```bash
 #make sure you are in your project directory
 git remote add starter git@github.com:dartmouth-cs52/express-babel-starter.git
-git pull starter master
+git pull starter main
 ```
 
 During SA7 we inspected the starterpack, it isn't very complicated - just express+babel+eslint (no webpack since we are using node).

--- a/assignments/sa/server-side/index.md
+++ b/assignments/sa/server-side/index.md
@@ -42,7 +42,7 @@ We're going to be building a poll site, where users can sign various polls. We w
 ```bash
 #make sure you are in your project directory
 git remote add starter git@github.com:dartmouth-cs52/express-babel-starter.git
-git pull starter master
+git pull starter main
 ```
 
 Then run these following commands to start our new node+express app in dev reloading mode.

--- a/resources/travis.md
+++ b/resources/travis.md
@@ -40,11 +40,11 @@ node_js:
 
         git add .travis.yml
         git commit -m 'Travis CI Config'
-        git push origin master
+        git push origin main
 
 5. Turn on GitHub Protected Branch.
 
-    You want to set up protected branches for your GitHub repository to ensure that all required CI tests are passing before collaborators can make changes to a protected branch. This will prevent potentially buggy code from being merged into master. To do so simply visit `https://github.com/<team>/<repo>/settings/branches` and turn on protected branch for `master`.
+    You want to set up protected branches for your GitHub repository to ensure that all required CI tests are passing before collaborators can make changes to a protected branch. This will prevent potentially buggy code from being merged into master. To do so simply visit `https://github.com/<team>/<repo>/settings/branches` and turn on protected branch for `main`.
 
     ![protected-branch](/assets/imgs/travis/protected-branch.jpg)
 


### PR DESCRIPTION
I switched the references from master to main for the express babel starter pack (and also one from the travis documentation).