### PR TITLE
fixing wrong year typo for Lab4

### DIFF
--- a/assignments/lab/redux-platform/index.md
+++ b/assignments/lab/redux-platform/index.md
@@ -42,7 +42,7 @@ We will rip out `platform.cs52.me/api` and build our own Nodejs+Express+Mongo ba
 
 ```bash
 #make sure you are in your project directory
-git remote add starter git@github.com:dartmouth-cs52-21s/starterpack-your-gitub-username.git
+git remote add starter URL_TO_YOUR_STARTERPACK
 git pull starter main  # you may need --allow-unrelated-histories
 ```
 

--- a/assignments/lab/redux-platform/index.md
+++ b/assignments/lab/redux-platform/index.md
@@ -42,7 +42,7 @@ We will rip out `platform.cs52.me/api` and build our own Nodejs+Express+Mongo ba
 
 ```bash
 #make sure you are in your project directory
-git remote add starter git@github.com:dartmouth-cs52-20s/starterpack-your-gitub-username.git
+git remote add starter git@github.com:dartmouth-cs52-21s/starterpack-your-gitub-username.git
 git pull starter main  # you may need --allow-unrelated-histories
 ```
 


### PR DESCRIPTION
In the index.md for lab 4 there was a typo in the year for pulling in the starterpack.